### PR TITLE
Fix filename in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ include = [
     "src/pbkdf2.rs",
     "src/pkcs8.rs",
     "src/polyfill.rs",
-    "src/polyfill/convert.rs",
+    "src/polyfill/chunks_fixed.rs",
     "src/rand.rs",
     "src/rsa/convert_nist_rsa_test_vectors.py",
     "src/rsa.rs",


### PR DESCRIPTION
https://github.com/felixonmars/ring/commit/67d8cee772a9fbc6d95889dd3d7d6b02d78ff429 added chunks_fixed.rs without modifying Cargo.toml. This patch fixes it.